### PR TITLE
Allow initialize to be called more than once

### DIFF
--- a/Chroma.cc
+++ b/Chroma.cc
@@ -16,7 +16,7 @@ NAN_METHOD(Initialize) {
         }
     }
 
-    if (SDKInstance.Init == NULL && SDKInstance.m_ChromaSDKModule!=NULL) {
+    if (SDKInstance.m_ChromaSDKModule!=NULL) {
         RZRESULT Result = RZRESULT_INVALID;
         SDKInstance.Init = (INIT)GetProcAddress(SDKInstance.m_ChromaSDKModule, "Init");
 


### PR DESCRIPTION
This PR allows you to release control back to Synapse, then take it back:

```js
r = require('razer-chroma');
r.initialize();
r.Keyboard.setWave();
r.terminate();              // Switches back to default

r.initialize();                // This fails without this PR
r.Keyboard.setStarlight();
```